### PR TITLE
patch: can specify response type when useApi init with generic param

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,20 +1,17 @@
 module.exports = {
-    root: true,
-    env: { browser: true, es2020: true },
-    extends: [
-      'eslint:recommended',
-      'plugin:@typescript-eslint/recommended',
-      'plugin:react-hooks/recommended',
-      'prettier',
-    ],
-    ignorePatterns: ['dist', '.eslintrc.cjs'],
-    parser: '@typescript-eslint/parser',
-    plugins: ['react-refresh', 'prettier'],
-    rules: {
-      'prettier/prettier': ['error'],
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
-    },
-  }
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'prettier',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh', 'prettier'],
+  rules: {
+    'prettier/prettier': ['error'],
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+  },
+}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,13 +5,12 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: ['main', 'dev']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -20,14 +19,14 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: rm package-lock.json
-    - run: rm -rf node_modules
-    - run: npm install
-    - run: npm run build
-    - run: npm test
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: rm package-lock.json
+      - run: rm -rf node_modules
+      - run: npm install
+      - run: npm run build
+      - run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: remove
         run: rm -rf node_modules package-lock.json
-        
+
       - name: Install dependencies
         run: npm install
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
-    "trailingComma": "es5",
-    "semi": false,
-    "singleQuote": true,
-    "printWidth": 100
+  "trailingComma": "es5",
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 100
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![npm version](https://img.shields.io/npm/v/useipa.svg?style=flat-square)](https://www.npmjs.org/package/useipa)
- &nbsp;
+&nbsp;
 [![Build status](https://img.shields.io/github/actions/workflow/status/abidta/useipa/CI.yml?branch=main&label=CI&logo=github&style=flat-square)](https://github.com/abidta/useipa/actions/workflows/ci.yml)
-# useipa Package 
+
+# useipa Package
+
 ### A Powerful and Lightweight React Hook for Managing API Calls and Forms
 
 The `useipa` package provides custom hooks for API interaction in React applications using Axios. It includes hooks for fetching data, mutating data, and submitting forms with integrated state management for loading, success, and error states.
@@ -69,11 +71,7 @@ const MutateComponent = () => {
 
   return (
     <div>
-      <input
-        type="text"
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-      />
+      <input type="text" value={inputValue} onChange={(e) => setInputValue(e.target.value)} />
       <button onClick={handleSubmit}>Submit</button>
       {success && <p>Success!</p>}
       {error && <p>Error: {error.message}</p>}
@@ -93,6 +91,7 @@ export default MutateComponent
 ### `useFormApi` Hook
 
 The `useFormApi` hook is designed for handling form submissions.
+
 - Extends `useApi` with a `submitForm` method for form submissions.
 - Inherits state management for `data`,` error`, `fetching`, and `success` from `useApi`.
 
@@ -118,18 +117,8 @@ const FormComponent = () => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <input
-        type="text"
-        name="name"
-        value={formData.name}
-        onChange={handleChange}
-      />
-      <input
-        type="email"
-        name="email"
-        value={formData.email}
-        onChange={handleChange}
-      />
+      <input type="text" name="name" value={formData.name} onChange={handleChange} />
+      <input type="email" name="email" value={formData.email} onChange={handleChange} />
       <button type="submit">Submit</button>
       {success && <p>Form submitted successfully!</p>}
       {error && <p>Error: {error.message}</p>}
@@ -153,12 +142,14 @@ export default FormComponent
 - Useful for cases where you don't need to manage state within a React component.
 
 #### Example: Async API Call
+
 ```js
 const getUsers = async () => {
-  const data = await asyncApi('/api/users');
-  console.log(data);
-};
+  const data = await asyncApi('/api/users')
+  console.log(data)
+}
 ```
+
 ### or
 
 ```jsx
@@ -199,23 +190,24 @@ export default AsyncComponent
 ### `useApi`
 
 - **State:**
+
   - `data`: The response data from the API.
   - `fetching`: A boolean indicating if the request is in progress.
   - `error`: An error object if the request fails.
   - `success`: A boolean indicating if the request was successful.
 
- **Methods:**
-  - `fetchData(endpoint, config?)`: Fetches data from an API endpoint.
-    - `endpoint`: The URL of the API endpoint.
-    - `config `(optional): An object containing configuration options like headers or method (defaults to `GET`).
-<br>
+  **Methods:**
+
+  - `fetchData(endpoint, config?)`: Fetches data from an API endpoint. - `endpoint`: The URL of the API endpoint. - `config `(optional): An object containing configuration options like headers or method (defaults to `GET`).
+    <br>
 
   - `mutate(endpoint, data, config?)`: Mutates data on an API endpoint.
+
     - `endpoint`: The URL of the API endpoint.
     - `data`: The data to be sent for mutation.
     - `config` (optional): An object containing configuration options like headers or method (defaults to `POST`).
- <br>
- 
+      <br>
+
   - `submitApi(endpointOrConfig, config?)` (internal method): Handles the actual API request.
     - `endpointOrConfig`: Either a string representing the endpoint URL or a configuration object.
     - `config `(optional): Additional configuration options for the request.
@@ -230,6 +222,7 @@ export default AsyncComponent
 ### `asyncApi`
 
 - **Parameters:**
+
   - `endpoint: string`: The API endpoint to call.
   - `method?: string`: The HTTP method to use (default is 'GET').
   - `config?: RequestConfig`: Additional configuration options for the request
@@ -245,10 +238,11 @@ const config = {
   headers: {
     Authorization: `Bearer ${myAuthToken}`,
   },
-};
+}
 
-fetchData('/api/data', config);
+fetchData('/api/data', config)
 ```
+
 ### Error Handling
 
 `useApi` logs errors to the console by default. You can implement custom error handling in your component.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "useipa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A react hook for api fetching",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import { useState } from 'react'
 import { AxiosResponse } from 'axios'
 import {
+  AsyncApi,
   FetchData,
   Mutate,
   RequestConfig,
   UseApi,
+  UseApiResponse,
   UseApiSubmit,
   UseForm,
   UseFormResponse,
@@ -24,11 +26,8 @@ api.interceptors.response.use(
     return Promise.reject(errObj ?? error)
   }
 )
-/**
- *
- * @returns
- */
-export const useApi: UseApi = () => {
+
+export const useApi: UseApi = <T>(): UseApiResponse<T> => {
   const [fetching, setFetching] = useState(false)
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
@@ -44,11 +43,8 @@ export const useApi: UseApi = () => {
 
   /**
    *
-   * @param endpoint
-   * @param body
-   * @param method
-   * @param params
-   * @param headers
+   * @param {(string|object)} endpointOrConfig
+   * @param {RequestConfig} [config]
    */
   const submitApi: UseApiSubmit = async (
     endpointOrConfig: string | RequestConfig,
@@ -73,8 +69,6 @@ export const useApi: UseApi = () => {
         setData(response)
       }
     } catch (error) {
-      // console.log('Error =>  ', error.message)
-
       const err = error as AxiosResponse
       setError(err.data ?? err)
     } finally {
@@ -91,21 +85,18 @@ export const useApi: UseApi = () => {
     submitApi,
   }
 }
-/**
- *
- * @param endpoint
- * @returns
- */
+
 export const useFormApi: UseForm = (): UseFormResponse => {
   const { data, fetching, error, success, submitApi } = useApi()
 
   /**
    *
-   * @param endpoint
-   * @param inputData
+   * @param {string} endpoint
+   * @param {object} formData
+   * @param {RequestConfig} [config]
    */
-  const submitForm = async (endpoint: string, inputData: object, config?: RequestConfig) => {
-    submitApi(endpoint, createConfig({ ...config, data: inputData }, 'mutate'))
+  const submitForm = async (endpoint: string, formData: object, config?: RequestConfig) => {
+    submitApi(endpoint, createConfig({ ...config, data: formData }, 'mutate'))
   }
   return {
     data,
@@ -118,11 +109,16 @@ export const useFormApi: UseForm = (): UseFormResponse => {
 
 /**
  *
- * @param endpoint
- * @param method
- * @returns Promise
+ * @param {string} endpoint
+ * @param {string} [method=GET]
+ * @param {RequestConfig} [config]
+ * @returns {Promise<any>}
  */
-export const asyncApi = async (endpoint: string, method = 'GET', config: RequestConfig) => {
+export const asyncApi: AsyncApi = async (
+  endpoint: string,
+  method = 'GET',
+  config?: RequestConfig
+) => {
   const { data } = await api({ ...config, url: endpoint, method })
   return data
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { AxiosRequestConfig } from 'axios'
+import { AxiosRequestConfig, Method } from 'axios'
 
 export type UseForm = () => UseFormResponse
 
@@ -13,7 +13,7 @@ export type UseFormResponse = {
  */
 export type UseApiResponse<D = any> = {
   fetching: boolean
-  data: D
+  data: D | null
   error?: Error | null
   success: boolean
   fetchData: FetchData
@@ -36,4 +36,5 @@ export type UseApiSubmit = {
   (endpoint: string, config: RequestConfig): void
 }
 
-export type UseApi = () => UseApiResponse
+export type AsyncApi = (endpoint: string, method?: Method, config?: RequestConfig) => Promise<any>
+export type UseApi = <T = any>() => UseApiResponse<T>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": [
-    "node_modules",
-    
-    "src/*.test.ts",
-  ]
+  "exclude": ["node_modules", "src/*.test.ts"]
 }


### PR DESCRIPTION
```ts
const response:ResponseExpectedType = {
  name: 'foo',
  age:25 
}

const {data,fetchData} = useApi<ResponseExpectedType>()
//you can access response propreties
console.log(data?.name,data?.age)
```
default type is `any`. it maybe `null`