### PR TITLE
patch: default abort signal time 5s to 30s

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "axios",
     "useapi",
     "useipa"
-    "react-api",
-    "react-hook"
   ],
   "author": "Sainul Abid",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "useipa",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A react hook for api fetching",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -33,6 +33,8 @@
     "axios",
     "useapi",
     "useipa"
+    "react-api",
+    "react-hook"
   ],
   "author": "Sainul Abid",
   "license": "MIT",

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,5 +1,5 @@
-export function abortSignal(ms: number) {
+export function abortSignal(ms?: number) {
   const controller = new AbortController()
-  setTimeout(() => controller.abort(), ms || 5000)
+  setTimeout(() => controller.abort(), ms || 30000)
   return controller.signal
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export const useApi: UseApi = (instanceConfig): UseApiResponse => {
       setError(null)
       setFetching(true)
       if (typeof endpointOrConfig === 'string' && typeof config === 'object') {
-        requestConfig = { ...config, url: endpointOrConfig }
+        requestConfig = createConfig({ ...config, url: endpointOrConfig })
       }
       if (typeof endpointOrConfig === 'string' && !config) {
         requestConfig = defaultConfig({ url: endpointOrConfig })

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type Mutate = (endpoint: string, data?: any, config?: RequestConfig) => v
 type SubmitForm = (endpoint: string, inputData: object) => void
 
 export type RequestConfig = {
+  signalTtl?: number
   identifier?: string
 } & AxiosRequestConfig
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ export const createConfig = (req: RequestConfig, apiType?: ApiType) => {
   return defaultConfig(req)
 }
 export const defaultConfig = (req?: RequestConfig): RequestConfig => {
-  return { ...req, withCredentials: true, signal: abortSignal(3000) }
+  return { ...req, signal: abortSignal(req?.signalTtl) }
 }
 
 export const instance = axios


### PR DESCRIPTION
can set custom abort signal ttl with reqConfig, rm withcredentials:true on default req config